### PR TITLE
disable popover when input is email & enale popover when previous input is space or new line

### DIFF
--- a/packages/test-e2e/tests/e2e/specs/defaults.js
+++ b/packages/test-e2e/tests/e2e/specs/defaults.js
@@ -98,19 +98,19 @@ describe('with default props', () => {
     cy.get('.preview').should('contain', '@akryumabc')
   })
 
-  // it('show suggestion when previous input is space', () => {
-  //   cy.visit('/defaults')
-  //   cy.get('.input').type(' @zzz')
-  //   cy.get('.popover').should('be.visible')
-  //   cy.get('.input').type('　@zzz')
-  //   cy.get('.popover').should('be.visible')
-  //   cy.get('.input').type('\n@zzz')
-  //   cy.get('.popover').should('be.visible')
-  // })
-  //
-  // it('does not show suggestion when text is email address', () => {
-  //   cy.visit('/defaults')
-  //   cy.get('.input').type('aaa@zzz.com')
-  //   cy.get('.popover').should('not.exist')
-  // })
+  it('show suggestion when previous input is space', () => {
+    cy.visit('/defaults')
+    cy.get('.input').type(' @zzz')
+    cy.get('.popover').should('be.visible')
+    cy.get('.input').type('　@zzz')
+    cy.get('.popover').should('be.visible')
+    cy.get('.input').type('\n@zzz')
+    cy.get('.popover').should('be.visible')
+  })
+
+  it('does not show suggestion when text is email address', () => {
+    cy.visit('/defaults')
+    cy.get('.input').type('aaa@zzz.com')
+    cy.get('.popover').should('not.exist')
+  })
 })

--- a/packages/test-e2e/tests/e2e/specs/defaults.js
+++ b/packages/test-e2e/tests/e2e/specs/defaults.js
@@ -97,4 +97,20 @@ describe('with default props', () => {
     cy.get('.input').type('@{enter}abc')
     cy.get('.preview').should('contain', '@akryumabc')
   })
+
+  // it('show suggestion when previous input is space', () => {
+  //   cy.visit('/defaults')
+  //   cy.get('.input').type(' @zzz')
+  //   cy.get('.popover').should('be.visible')
+  //   cy.get('.input').type('　@zzz')
+  //   cy.get('.popover').should('be.visible')
+  //   cy.get('.input').type('\n@zzz')
+  //   cy.get('.popover').should('be.visible')
+  // })
+  //
+  // it('does not show suggestion when text is email address', () => {
+  //   cy.visit('/defaults')
+  //   cy.get('.input').type('aaa@zzz.com')
+  //   cy.get('.popover').should('not.exist')
+  // })
 })

--- a/packages/vue-mention/src/Mentionable.vue
+++ b/packages/vue-mention/src/Mentionable.vue
@@ -242,6 +242,9 @@ export default {
       if (index >= 0) {
         const { key, keyIndex } = this.getLastKeyBeforeCaret(index)
         const searchText = this.getLastSearchText(index, keyIndex)
+        if (!(keyIndex < 1 || /\r\n|\r|\n|\s/.test(this.getValue()[keyIndex - 1]))) {
+          return false
+        }
         if (searchText != null) {
           this.openMenu(key, keyIndex)
           this.searchText = searchText

--- a/packages/vue-mention/src/Mentionable.vue
+++ b/packages/vue-mention/src/Mentionable.vue
@@ -242,7 +242,7 @@ export default {
       if (index >= 0) {
         const { key, keyIndex } = this.getLastKeyBeforeCaret(index)
         const searchText = this.getLastSearchText(index, keyIndex)
-        if (!(keyIndex < 1 || /\r\n|\r|\n|\s/.test(this.getValue()[keyIndex - 1]))) {
+        if (!(keyIndex < 1 || /\s/.test(this.getValue()[keyIndex - 1]))) {
           return false
         }
         if (searchText != null) {


### PR DESCRIPTION
This pull request is the following logics of popover.

- I don't want to showing popover when I input `hogehoge@gmail.com`.
- I want to showing popover when I input ` @zzz`.
- I want to showing popover when I input `　@zzz`.
- I want to showing popover when I input `hello.\n@zzz`.

I think the logic is same as slack and teams.

But this is not pretty code... 🙏 