### PR TITLE
Add close event and tests

### DIFF
--- a/packages/test-e2e/src/views/SearchEvent.vue
+++ b/packages/test-e2e/src/views/SearchEvent.vue
@@ -18,6 +18,8 @@ export default {
         },
       ],
       searchText: null,
+      openKey: null,
+      closeKey: null,
     }
   },
 }
@@ -31,6 +33,8 @@ export default {
       :keys="['@']"
       :items="items"
       @search="searchText = $event"
+      @open="openKey = $event"
+      @close="closeKey = $event"
     >
       <textarea
         v-model="text"
@@ -40,5 +44,7 @@ export default {
     </Mentionable>
 
     <div class="search">{{ searchText }}</div>
+    <div class="open">{{ openKey }}</div>
+    <div class="close">{{ closeKey }}</div>
   </div>
 </template>

--- a/packages/test-e2e/tests/e2e/specs/events.js
+++ b/packages/test-e2e/tests/e2e/specs/events.js
@@ -6,3 +6,16 @@ describe('search event', () => {
     cy.get('.search').should('contain', 'pos')
   })
 })
+
+describe('open and close events', () => {
+  it('emits open and close events', () => {
+    cy.visit('/search-event')
+    cy.get('.input').type('@pos')
+    cy.get('.popover').should('be.visible')
+    cy.get('.open').should('contain', 'posva')
+    cy.get('.close').should('not.contain', 'posva')
+    cy.get('.input').clear()
+    cy.get('.popover').should('not.be.visible')
+    cy.get('.close').should('contain', 'posva')
+  })
+})

--- a/packages/test-e2e/tests/e2e/specs/events.js
+++ b/packages/test-e2e/tests/e2e/specs/events.js
@@ -16,6 +16,6 @@ describe('open and close events', () => {
     cy.get('.close').should('not.contain', 'posva')
     cy.get('.input').clear()
     cy.get('.popover').should('not.be.visible')
-    cy.get('.close').should('contain', 'posva')
+    cy.get('.close').should('contain', '@')
   })
 })

--- a/packages/vue-mention/src/Mentionable.vue
+++ b/packages/vue-mention/src/Mentionable.vue
@@ -282,9 +282,11 @@ export default {
     },
 
     closeMenu () {
-      this.oldKey = this.key
-      this.key = null
-      this.$emit('close', this.oldKey)
+      if (this.key != null) {
+        this.oldKey = this.key
+        this.key = null
+        this.$emit('close', this.oldKey)
+      }
     },
 
     updateCaretPosition () {

--- a/packages/vue-mention/src/Mentionable.vue
+++ b/packages/vue-mention/src/Mentionable.vue
@@ -284,6 +284,7 @@ export default {
     closeMenu () {
       this.oldKey = this.key
       this.key = null
+      this.$emit('close', this.oldKey)
     },
 
     updateCaretPosition () {


### PR DESCRIPTION
I need to detect externally when the mention selector closes, this will allow enter events used externally to be cancelled when mention is open

Closes #8
