### PR TITLE
feat: extend items with image url

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ const users = [
   {
     value: 'akryum',
     firstName: 'Guillaume',
+    imgUrl: 'https://via.placeholder.com/25x25',
   },
   {
     value: 'posva',
     firstName: 'Eduardo',
+    imgUrl: 'https://via.placeholder.com/25x25',
   },
   {
     value: 'atinux',
     firstName: 'Sébastien',
+    imgUrl: 'https://via.placeholder.com/25x25',
   },
 ]
 

--- a/packages/vue-mention/src/Mentionable.vue
+++ b/packages/vue-mention/src/Mentionable.vue
@@ -399,7 +399,8 @@ export default {
                 :item="item"
                 :index="index"
               >
-                {{ item.label || item.value }}
+                <img class="item-img" :src="item.imgUrl" v-if="item.imgUrl"/>
+                <span class="item-text">{{ item.label || item.value }}</span>
               </slot>
             </slot>
           </div>
@@ -408,3 +409,10 @@ export default {
     </VPopover>
   </div>
 </template>
+
+<style>
+  .item-img {
+    max-width: 25px;
+    margin-right: 5px;
+  }
+</style>


### PR DESCRIPTION
I extended the plugin to also allow optional imageUrl as an item option to show icons or user images next to the mentioned name. 
I also surrounded the items label with a span to allow more customization on the styling.