### PR TITLE
Add class name to no result element

### DIFF
--- a/packages/vue-mention/src/Mentionable.vue
+++ b/packages/vue-mention/src/Mentionable.vue
@@ -401,7 +401,7 @@ export default defineComponent({
       />
 
       <template #popper>
-        <div v-if="!displayedItems.length">
+        <div v-if="!displayedItems.length" class="no-result">
           <slot name="no-result">
             No result
           </slot>


### PR DESCRIPTION
I added class name to no result element because make it easy to custom css.